### PR TITLE
fix: use only evaluated games for final round, add @Transactional annotation to deleteAllByFinalGameTrue

### DIFF
--- a/src/main/java/de/fsr/mariokart_backend/MarioKartStartupRunner.java
+++ b/src/main/java/de/fsr/mariokart_backend/MarioKartStartupRunner.java
@@ -116,6 +116,10 @@ public class MarioKartStartupRunner implements CommandLineRunner {
     }
 
     private void addTeams() {
+        if (teamRepository.findAll().size() > 0) {
+            System.err.print("Teams already exist!");
+            return;
+        }
         try {
             adminSettingsUpdateService.updateSettings(new TournamentDTO(true, true, 6));
             TeamInputDTO team1 = new TeamInputDTO("TollerTeamName", "Mario");

--- a/src/main/java/de/fsr/mariokart_backend/registration/service/admin/AdminRegistrationReadService.java
+++ b/src/main/java/de/fsr/mariokart_backend/registration/service/admin/AdminRegistrationReadService.java
@@ -29,8 +29,17 @@ public class AdminRegistrationReadService {
                 .toList();
     }
 
-    public List<TeamReturnDTO> getTeamsSortedByGroupPoints() {
-        List<TeamReturnDTO> teams = teamRepository.findAllByOrderByGroupPointsDesc().stream()
+    public List<Team> getTeamsSortedByGroupPoints() {
+        List<Team> teams = teamRepository.findAll().stream()
+                .sorted(Comparator.comparing(
+                        team -> team.getGroupPoints(publicSettingsReadService.getSettings().getMaxGamesCount()),
+                        Comparator.reverseOrder()))
+                .toList();
+        return teams;
+    }
+
+    public List<TeamReturnDTO> getTeamsReturnDTOSortedByGroupPoints() {
+        List<TeamReturnDTO> teams = getTeamsSortedByGroupPoints().stream()
                 .map(registrationReturnDTOService::teamToTeamReturnDTO)
                 .toList();
         if (teams.isEmpty()) {
@@ -56,11 +65,8 @@ public class AdminRegistrationReadService {
     }
 
     public List<Team> getFinalTeams() {
-        return teamRepository.findByFinalReadyTrue().stream()
-                .sorted(Comparator.comparing(
-                        team -> team.getGroupPoints(publicSettingsReadService.getSettings().getMaxGamesCount()),
-                        Comparator.reverseOrder()))
-                .limit(4)
+        return getTeamsSortedByGroupPoints().stream()
+                .filter(team -> team.isFinalReady())
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/de/fsr/mariokart_backend/registration/service/admin/AdminRegistrationReadService.java
+++ b/src/main/java/de/fsr/mariokart_backend/registration/service/admin/AdminRegistrationReadService.java
@@ -67,6 +67,7 @@ public class AdminRegistrationReadService {
     public List<Team> getFinalTeams() {
         return getTeamsSortedByGroupPoints().stream()
                 .filter(team -> team.isFinalReady())
+                .limit(4)
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/de/fsr/mariokart_backend/registration/service/pub/PublicRegistrationReadService.java
+++ b/src/main/java/de/fsr/mariokart_backend/registration/service/pub/PublicRegistrationReadService.java
@@ -33,7 +33,7 @@ public class PublicRegistrationReadService {
     }
 
     public List<TeamReturnDTO> getTeamsSortedByGroupPoints() {
-        List<TeamReturnDTO> teams = adminRegistrationReadService.getTeamsSortedByGroupPoints();
+        List<TeamReturnDTO> teams = adminRegistrationReadService.getTeamsReturnDTOSortedByGroupPoints();
         return deleteUnnecessaryInformationFromTeams(teams);
     }
 

--- a/src/main/java/de/fsr/mariokart_backend/schedule/repository/RoundRepository.java
+++ b/src/main/java/de/fsr/mariokart_backend/schedule/repository/RoundRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import de.fsr.mariokart_backend.schedule.model.Round;
 
@@ -23,5 +24,6 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
     Integer countByPlayedFalse();
 
+    @Transactional
     void deleteAllByFinalGameTrue();
 }

--- a/src/main/java/de/fsr/mariokart_backend/schedule/service/admin/AdminScheduleCreateService.java
+++ b/src/main/java/de/fsr/mariokart_backend/schedule/service/admin/AdminScheduleCreateService.java
@@ -16,6 +16,7 @@ import de.fsr.mariokart_backend.exception.NotificationNotSentException;
 import de.fsr.mariokart_backend.exception.RoundsAlreadyExistsException;
 import de.fsr.mariokart_backend.registration.model.Team;
 import de.fsr.mariokart_backend.registration.repository.TeamRepository;
+import de.fsr.mariokart_backend.registration.service.admin.AdminRegistrationReadService;
 import de.fsr.mariokart_backend.schedule.model.Break;
 import de.fsr.mariokart_backend.schedule.model.Game;
 import de.fsr.mariokart_backend.schedule.model.Points;
@@ -50,6 +51,7 @@ public class AdminScheduleCreateService {
 
     private final AdminScheduleUpdateService adminScheduleUpdateService;
     private final AdminSettingsUpdateService adminSettingsUpdateService;
+    private final AdminRegistrationReadService adminRegistrationReadService;
     private final PublicScheduleReadService publicScheduleReadService;
     private final ScheduleInputDTOService scheduleInputDTOService;
     private final ScheduleReturnDTOService scheduleReturnDTOService;
@@ -102,12 +104,7 @@ public class AdminScheduleCreateService {
             throw new NotEnoughTeamsException("Not enough teams ready for final");
         }
 
-        List<Team> teams = teamRepository.findByFinalReadyTrue();
-        teams.sort((t1, t2) -> {
-            int t1Points = t1.getPoints().stream().mapToInt(Points::getGroupPoints).sum();
-            int t2Points = t2.getPoints().stream().mapToInt(Points::getGroupPoints).sum();
-            return t2Points - t1Points;
-        });
+        List<Team> teams = adminRegistrationReadService.getFinalTeams();
 
         if (teams.size() > 4) {
             teams = teams.subList(0, 4);


### PR DESCRIPTION
- use only evaluated games for final round computation
- add @Transactional annotation to deleteAllByFinalGameTrue
- prevent adding dummy teams if they already exist