### PR TITLE
build: lock Spring Boot version to 3

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
     ignore:
       - dependency-name: "org.springframework.boot:spring-boot-starter-parent"
         versions:
-        - "> 3"
+        - ">= 4"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Ignore updates for spring-boot-starter-parent above version 3